### PR TITLE
Implement cumulative variables for common surface fluxes

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2018,7 +2018,7 @@
 
                 <nml_option name="config_bucket_update" type="character" default_value="none"
                      units="-"
-                     description="time interval between updates of accumulated rain and radiation diagnostics"
+                     description="time interval between updates of accumulated rain, radiation and surface flux diagnostics"
                      possible_values="`DD_HH:MM:SS' or `none'"/>
 
                 <nml_option name="config_physics_suite" type="character" default_value="mesoscale_reference" in_defaults="true"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -672,6 +672,12 @@
                <var name="qc_bl"/>
                <var name="qi_bl"/>
                <var name="ch"/>
+			<var name="i_achfx"/>
+			<var name="i_acqfx"/>
+			<var name="i_aclh"/>
+			<var name="achfx"/>
+			<var name="acqfx"/>
+			<var name="aclh"/>
 			<var name="kpbl"/>
 			<var name="hpbl"/>
 			<var name="hfx"/>
@@ -751,6 +757,10 @@
 			<var name="glw"/>
 			<var name="o3clim"/>
 			<var name="o3vmr"/>
+			<var name="i_acgrdflx"/>
+			<var name="i_acnoahres"/>
+			<var name="acgrdflx"/>
+			<var name="acnoahres"/>
 			<var name="acsnom"/>
 			<var name="acsnow"/>
 			<var name="canwat"/>
@@ -2170,6 +2180,11 @@
                      description="threshold above which the accumulated grid-scale precipitation is reset"
                      possible_values="Positive real values"/>
 
+                <nml_option name="config_bucket_sflx" type="real" default_value="1.0e9" in_defaults="false"
+                     units="-"
+                     description="threshold above which the absolute accumulated surface flux diagnostics are reset"
+                     possible_values="Positive real values"/>
+
                 <nml_option name="config_oml1d" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="Whether to activate the 1-d ocean mixed-layer model"
@@ -2668,6 +2683,18 @@
                 <!-- ... PARAMETERIZATION OF SURFACE LAYER PROCESSES:                                                   -->
                 <!-- ================================================================================================== -->
 
+                <var name="i_achfx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute heat flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="i_acqfx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute moisture flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="i_aclh" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute latent heat flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
                 <var name="hfx" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="upward heat flux at the surface"
                      packages="bl_mynn_in;bl_ysu_in"/>
@@ -2782,6 +2809,18 @@
 
                 <var name="lh_spr" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="latent heat flux at the surface from ocean spray"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="achfx" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated upward heat flux at the surface"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="acqfx" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="accumulated upward moisture flux at the surface"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="aclh" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated latent heat flux at the surface"
                      packages="bl_mynn_in;bl_ysu_in"/>
 
 
@@ -2909,28 +2948,28 @@
                 <var name="swuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward surface shortwave radiation flux"/>
 
-                <var name="acswdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward surface shortwave radiation flux"/>
 
-                <var name="acswdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdntc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswupb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswupb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward surface shortwave radiation flux"/>
 
                 <var name="acswupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward surface shortwave radiation flux"/>
 
-                <var name="acswupt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswupt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswuptc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swddir" type="real" dimensions="nCells Time" units="W m^{-2}"
@@ -3020,28 +3059,28 @@
                 <var name="lwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward surface longwave radiation flux"/>
 
-                <var name="aclwdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward surface longwave radiation flux"/>
 
-                <var name="aclwdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdntc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwupb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward surface longwave radiation flux"/>
 
-                <var name="aclwupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward surface longwave radiation flux"/>
 
-                <var name="aclwupt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwuptc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="olrtoa" type="real" dimensions="nCells Time" units="W m^{-2}"
@@ -3103,6 +3142,12 @@
                 <!-- ================================================================================================== -->
                 <!-- ... PARAMETERIZATION OF LAND-SURFACE SCHEME:                                                       -->
                 <!-- ================================================================================================== -->
+
+                <var name="i_acgrdflx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated absolute ground heat flux greater than config_bucket_sflx"/>
+
+                <var name="i_acnoahres" type="real" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated residual of the Noah surface energy budget greater than config_bucket_sflx"/>
 
                 <var name="acsnom" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="accumulated melted snow"/>
@@ -3178,6 +3223,12 @@
 
                 <var name="zs" type="real" dimensions="nCells Time" units="m"
                      description="depth of centers of soil layers"/>
+
+                <var name="acgrdflx" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated ground heat flux"/>
+
+                <var name="acnoahres" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated residual of the Noah surface energy budget"/>
 
                 <!-- ================================================================================================== -->
                 <!-- ... PARAMETERIZATION OF THE 1D OCEAN MIXED LAYER                                                   -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3146,7 +3146,7 @@
                 <var name="i_acgrdflx" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated absolute ground heat flux greater than config_bucket_sflx"/>
 
-                <var name="i_acnoahres" type="real" dimensions="nCells Time" units="unitless"
+                <var name="i_acnoahres" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated residual of the Noah surface energy budget greater than config_bucket_sflx"/>
 
                 <var name="acsnom" type="real" dimensions="nCells Time" units="kg m^{-2}"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -716,6 +716,12 @@
                         <var name="qc_bl"/>
                         <var name="qi_bl"/>
                         <var name="ch"/>
+			<var name="i_achfx"/>
+			<var name="i_acqfx"/>
+			<var name="i_aclh"/>
+			<var name="achfx"/>
+			<var name="acqfx"/>
+			<var name="aclh"/>
 			<var name="kpbl"/>
 			<var name="hpbl"/>
 			<var name="hfx"/>
@@ -795,6 +801,10 @@
 			<var name="glw"/>
 			<var name="o3clim"/>
 			<var name="o3vmr"/>
+			<var name="i_acgrdflx"/>
+			<var name="i_acnoahres"/>
+			<var name="acgrdflx"/>
+			<var name="acnoahres"/>
 			<var name="acsnom"/>
 			<var name="acsnow"/>
 			<var name="canwat"/>
@@ -2456,6 +2466,11 @@
                      description="threshold above which the accumulated grid-scale precipitation is reset"
                      possible_values="Positive real values"/>
 
+                <nml_option name="config_bucket_sflx" type="real" default_value="1.0e9" in_defaults="false"
+                     units="-"
+                     description="threshold above which the absolute accumulated surface flux diagnostics are reset"
+                     possible_values="Positive real values"/>
+
                 <nml_option name="config_oml1d" type="logical" default_value="false" in_defaults="false"
                      units="-"
                      description="Whether to activate the 1-d ocean mixed-layer model"
@@ -2970,6 +2985,18 @@
                 <!-- ... PARAMETERIZATION OF SURFACE LAYER PROCESSES:                                                   -->
                 <!-- ================================================================================================== -->
 
+                <var name="i_achfx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute heat flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="i_acqfx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute moisture flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="i_aclh" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of absolute latent heat flux at the surface greater than config_bucket_sflx"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
                 <var name="hfx" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="upward heat flux at the surface"
                      packages="bl_mynn_in;bl_ysu_in"/>
@@ -3084,6 +3111,18 @@
 
                 <var name="lh_spr" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="latent heat flux at the surface from ocean spray"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="achfx" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated upward heat flux at the surface"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="acqfx" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="accumulated upward moisture flux at the surface"
+                     packages="bl_mynn_in;bl_ysu_in"/>
+
+                <var name="aclh" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated latent heat flux at the surface"
                      packages="bl_mynn_in;bl_ysu_in"/>
 
 
@@ -3293,28 +3332,28 @@
                 <var name="swuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward surface shortwave radiation flux"/>
 
-                <var name="acswdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward surface shortwave radiation flux"/>
 
-                <var name="acswdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdnt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswdntc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswupb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswupb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward surface shortwave radiation flux"/>
 
                 <var name="acswupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="accumulated clear-sky upward surface shortwave radiation flux"/>
 
-                <var name="acswupt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswupt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward top-of-atmosphere shortwave radiation flux"/>
 
-                <var name="acswuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="acswuptc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward top-of-atmosphere shortwave radiation flux"/>
 
                 <var name="swddir" type="real" dimensions="nCells Time" units="W m^{-2}"
@@ -3404,28 +3443,28 @@
                 <var name="lwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
                      description="clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwdnb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward surface longwave radiation flux"/>
 
-                <var name="aclwdnbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward surface longwave radiation flux"/>
 
-                <var name="aclwdnt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdnt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwdntc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwdntc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky downward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwupb" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupb" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward surface longwave radiation flux"/>
 
-                <var name="aclwupbc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupbc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward surface longwave radiation flux"/>
 
-                <var name="aclwupt" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwupt" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated all-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
-                <var name="aclwuptc" type="real" dimensions="nCells Time" units="W m^{-2}"
+                <var name="aclwuptc" type="real" dimensions="nCells Time" units="J m^{-2}"
                      description="accumulated clear-sky upward top-of-the-atmosphere longwave radiation flux"/>
 
                 <var name="olrtoa" type="real" dimensions="nCells Time" units="W m^{-2}"
@@ -3501,6 +3540,12 @@
                 <!-- ... PARAMETERIZATION OF LAND-SURFACE SCHEME:                                                       -->
                 <!-- ================================================================================================== -->
 
+                <var name="i_acgrdflx" type="integer" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated absolute ground heat flux greater than config_bucket_sflx"/>
+
+                <var name="i_acnoahres" type="real" dimensions="nCells Time" units="unitless"
+                     description="incidence of accumulated residual of the Noah surface energy budget greater than config_bucket_sflx"/>
+
                 <var name="acsnom" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="accumulated melted snow"/>
 
@@ -3575,6 +3620,12 @@
 
                 <var name="zs" type="real" dimensions="nCells Time" units="m"
                      description="depth of centers of soil layers"/>
+
+                <var name="acgrdflx" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated ground heat flux"/>
+
+                <var name="acnoahres" type="real" dimensions="nCells Time" units="J m^{-2}"
+                     description="accumulated residual of the Noah surface energy budget"/>
 
                 <!-- ================================================================================================== -->
                 <!-- ... PARAMETERIZATION OF THE 1D OCEAN MIXED LAYER                                                   -->

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -3543,7 +3543,7 @@
                 <var name="i_acgrdflx" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated absolute ground heat flux greater than config_bucket_sflx"/>
 
-                <var name="i_acnoahres" type="real" dimensions="nCells Time" units="unitless"
+                <var name="i_acnoahres" type="integer" dimensions="nCells Time" units="unitless"
                      description="incidence of accumulated residual of the Noah surface energy budget greater than config_bucket_sflx"/>
 
                 <var name="acsnom" type="real" dimensions="nCells Time" units="kg m^{-2}"

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -2276,7 +2276,7 @@
 
                 <nml_option name="config_bucket_update" type="character" default_value="none"
                      units="-"
-                     description="time interval between updates of accumulated rain and radiation diagnostics"
+                     description="time interval between updates of accumulated rain, radiation and surface flux diagnostics"
                      possible_values="`DD_HH:MM:SS' or `none'"/>
 
                 <nml_option name="config_physics_suite" type="character" default_value="mesoscale_reference" in_defaults="true"

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -89,7 +89,7 @@
 ! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
 ! update_convection_step2     : updates accumulated precipitation output from convection schemes.
 ! update_radiation_diagnostics: updates accumulated radiation diagnostics from radiation schemes.
-! update_lsm_diagnostics      : updates accumualted surface flux diagnostics from LSM schemes.
+! update_sfcflux_diagnostics  : updates accumulated surface flux diagnostics from LSM/Sfc layer schemes.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -318,8 +318,8 @@
      if(config_bucket_update /= 'none' .or. config_bucket_sflx > 0._RKIND) then
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call update_sflx_diagnostics(block%configs,mesh,diag_physics, &
-                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+          call update_sfcflux_diagnostics(block%configs,mesh,diag_physics, &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO
      endif

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -88,7 +88,8 @@
 ! driver_sfclayer             : driver for surface layer scheme.
 ! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
 ! update_convection_step2     : updates accumulated precipitation output from convection schemes.
-! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
+! update_radiation_diagnostics: updates accumulated radiation diagnostics from radiation schemes.
+! update_lsm_diagnostics      : updates accumualted surface flux diagnostics from LSM schemes.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
@@ -309,6 +310,18 @@
 !$OMP END PARALLEL DO
        call deallocate_seaice
     endif
+
+
+    !call to accumulate surface flux diagnostics if needed:
+     if(config_bucket_update /= 'none' .or. config_bucket_sflx .gt. 0._RKIND) then
+!$OMP PARALLEL DO
+       do thread=1,nThreads
+          call update_sflx_diagnostics(block%configs,mesh,diag_physics, &
+                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+       end do
+!$OMP END PARALLEL DO
+     endif
+
 
     !call to pbl schemes:
     if(config_pbl_scheme .ne. 'off' .and. config_sfclayer_scheme .ne. 'off') then

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -157,6 +157,7 @@
 
  logical, pointer:: config_oml1d
  real(kind=RKIND),pointer:: config_bucket_radt
+ real(kind=RKIND),pointer:: config_bucket_sflx
 
 !local variables:
  type(block_type),pointer:: block
@@ -181,6 +182,7 @@
  call mpas_pool_get_config(domain%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(domain%configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
  call mpas_pool_get_config(domain%configs,'config_bucket_radt'      ,config_bucket_radt      )
+ call mpas_pool_get_config(domain%configs,'config_bucket_sflx'      ,config_bucket_sflx      )
  call mpas_pool_get_config(domain%configs,'config_bucket_update'    ,config_bucket_update    )
  call mpas_pool_get_config(domain%configs,'config_frac_seaice'      ,config_frac_seaice      ) 
  call mpas_pool_get_config(domain%configs,'config_oml1d'            ,config_oml1d            )
@@ -313,7 +315,7 @@
 
 
     !call to accumulate surface flux diagnostics if needed:
-     if(config_bucket_update /= 'none' .or. config_bucket_sflx .gt. 0._RKIND) then
+     if(config_bucket_update /= 'none' .or. config_bucket_sflx > 0._RKIND) then
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call update_sflx_diagnostics(block%configs,mesh,diag_physics, &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -166,6 +166,7 @@
 
  logical, pointer:: config_oml1d
  real(kind=RKIND),pointer:: config_bucket_radt
+ real(kind=RKIND),pointer:: config_bucket_sflx
 
 !local variables:
  type(block_type),pointer:: block
@@ -190,6 +191,7 @@
  call mpas_pool_get_config(domain%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
  call mpas_pool_get_config(domain%configs,'config_sfclayer_scheme'  ,config_sfclayer_scheme  )
  call mpas_pool_get_config(domain%configs,'config_bucket_radt'      ,config_bucket_radt      )
+ call mpas_pool_get_config(domain%configs,'config_bucket_sflx'      ,config_bucket_sflx      )
  call mpas_pool_get_config(domain%configs,'config_bucket_update'    ,config_bucket_update    )
  call mpas_pool_get_config(domain%configs,'config_frac_seaice'      ,config_frac_seaice      ) 
  call mpas_pool_get_config(domain%configs,'config_oml1d'            ,config_oml1d            )
@@ -341,7 +343,7 @@
 
 
     !call to accumulate surface flux diagnostics if needed:
-     if(config_bucket_update /= 'none' .or. config_bucket_sflx .gt. 0._RKIND) then
+     if(config_bucket_update /= 'none' .or. config_bucket_sflx > 0._RKIND) then
 !$OMP PARALLEL DO
        do thread=1,nThreads
           call update_sflx_diagnostics(block%configs,mesh,diag_physics, &

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -90,7 +90,8 @@
 ! driver_sfclayer             : driver for surface layer scheme.
 ! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
 ! update_convection_step2     : updates accumulated precipitation output from convection schemes.
-! update_radiation_diagnostics: updates accumualted radiation diagnostics from radiation schemes.
+! update_radiation_diagnostics: updates accumulated radiation diagnostics from radiation schemes.
+! update_lsm_diagnostics      : updates accumualted surface flux diagnostics from LSM schemes.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
@@ -337,6 +338,18 @@
        enddo
 !$OMP END PARALLEL DO
     endif
+
+
+    !call to accumulate surface flux diagnostics if needed:
+     if(config_bucket_update /= 'none' .or. config_bucket_sflx .gt. 0._RKIND) then
+!$OMP PARALLEL DO
+       do thread=1,nThreads
+          call update_sflx_diagnostics(block%configs,mesh,diag_physics, &
+                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+       end do
+!$OMP END PARALLEL DO
+     endif
+
 
     !call to pbl schemes:
     if(config_pbl_scheme .ne. 'off' .and. config_sfclayer_scheme .ne. 'off') then

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -346,8 +346,8 @@
      if(config_bucket_update /= 'none' .or. config_bucket_sflx > 0._RKIND) then
 !$OMP PARALLEL DO
        do thread=1,nThreads
-          call update_sflx_diagnostics(block%configs,mesh,diag_physics, &
-                                       cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
+          call update_sfcflux_diagnostics(block%configs,mesh,diag_physics, &
+                                          cellSolveThreadStart(thread), cellSolveThreadEnd(thread))
        end do
 !$OMP END PARALLEL DO
      endif

--- a/src/core_atmosphere/physics/mpas_atmphys_driver.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver.F
@@ -91,7 +91,7 @@
 ! update_convection_step1     : updates lifetime of deep convective clouds in Kain-Fritsch scheme.
 ! update_convection_step2     : updates accumulated precipitation output from convection schemes.
 ! update_radiation_diagnostics: updates accumulated radiation diagnostics from radiation schemes.
-! update_lsm_diagnostics      : updates accumualted surface flux diagnostics from LSM schemes.
+! update_sfcflux_diagnostics  : updates accumulated surface flux diagnostics from LSM/Sfc layer schemes.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -113,11 +113,13 @@
                                   i_acswupb,i_acswupbc,i_acswupt,i_acswuptc, &
                                   i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
                                   i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
+ integer,dimension(:),pointer  :: i_achfx,i_acqfx,i_aclh,i_acgrdflx,i_acnoahres
 
  real(kind=RKIND),dimension(:),pointer  :: acswdnb,acswdnbc,acswdnt,acswdntc,  &
                                            acswupb,acswupbc,acswupt,acswuptc,  &
                                            aclwdnb,aclwdnbc,aclwdnt,aclwdntc,  &
                                            aclwupb,aclwupbc,aclwupt,aclwuptc
+ real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,ac_noahres
  real(kind=RKIND),dimension(:),pointer  :: nsteps_accum,ndays_accum,tday_accum, &
                                            tyear_accum,tyear_mean
  real(kind=RKIND),dimension(:),pointer  :: sst,sstsk,tmn,xice,xicem
@@ -172,6 +174,12 @@
  call mpas_pool_get_array(diag_physics,'i_aclwupt'   ,i_aclwupt   )
  call mpas_pool_get_array(diag_physics,'i_aclwuptc'  ,i_aclwuptc  )
 
+ call mpas_pool_get_array(diag_physics,'i_achfx'     ,i_achfx     )
+ call mpas_pool_get_array(diag_physics,'i_acqfx'     ,i_acqfx     )
+ call mpas_pool_get_array(diag_physics,'i_aclh'      ,i_aclh      )
+ call mpas_pool_get_array(diag_physics,'i_acgrdflx'  ,i_acgrdflx  )
+ call mpas_pool_get_array(diag_physics,'i_acnoahres' ,i_acnoahres )
+
  call mpas_pool_get_array(diag_physics,'acswdnb'     ,acswdnb     )
  call mpas_pool_get_array(diag_physics,'acswdnbc'    ,acswdnbc    )
  call mpas_pool_get_array(diag_physics,'acswdnt'     ,acswdnt     )
@@ -188,6 +196,12 @@
  call mpas_pool_get_array(diag_physics,'aclwupbc'    ,aclwupbc    )
  call mpas_pool_get_array(diag_physics,'aclwupt'     ,aclwupt     )
  call mpas_pool_get_array(diag_physics,'aclwuptc'    ,aclwuptc    )
+
+ call mpas_pool_get_array(diag_physics,'achfx'       ,achfx       )
+ call mpas_pool_get_array(diag_physics,'acqfx'       ,acqfx       )
+ call mpas_pool_get_array(diag_physics,'aclh'        ,aclh        )
+ call mpas_pool_get_array(diag_physics,'acgrdflx'    ,acgrdflx    )
+ call mpas_pool_get_array(diag_physics,'acnoahres'   ,acnoahres   )
 
  call mpas_pool_get_array(diag_physics,'nsteps_accum',nsteps_accum)
  call mpas_pool_get_array(diag_physics,'ndays_accum' ,ndays_accum )
@@ -279,6 +293,25 @@
        aclwupbc(iCell) = 0._RKIND
        aclwupt(iCell)  = 0._RKIND
        aclwuptc(iCell) = 0._RKIND
+    enddo
+ endif
+
+! Initialisation of accumlated surface fluxes and corresponding counters (i_ac*). Counters i_ac* track
+! the number of times the absolute value of the accumulated surface fluxes exceed their prescribed 
+! threshold values.
+ if(.not. config_do_restart .and. config_lsm_scheme.ne.'off') then
+    do iCell = 1, nCellsSolve
+       i_achfx    (iCell) = 0
+       i_acqfx    (iCell) = 0
+       i_aclh     (iCell) = 0
+       i_acgrdflx (iCell) = 0
+       i_acnoahres(iCell) = 0
+
+       achfx      (iCell) = 0._RKIND
+       acqfx      (iCell) = 0._RKIND
+       aclh       (iCell) = 0._RKIND
+       acgrdflx   (iCell) = 0._RKIND
+       acnoahres  (iCell) = 0._RKIND
     enddo
  endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -119,7 +119,7 @@
                                            acswupb,acswupbc,acswupt,acswuptc,  &
                                            aclwdnb,aclwdnbc,aclwdnt,aclwdntc,  &
                                            aclwupb,aclwupbc,aclwupt,aclwuptc
- real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,ac_noahres
+ real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,acnoahres
  real(kind=RKIND),dimension(:),pointer  :: nsteps_accum,ndays_accum,tday_accum, &
                                            tyear_accum,tyear_mean
  real(kind=RKIND),dimension(:),pointer  :: sst,sstsk,tmn,xice,xicem

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -131,7 +131,7 @@ use mpas_stream_manager
                                          acswupb,acswupbc,acswupt,acswuptc, &
                                          aclwdnb,aclwdnbc,aclwdnt,aclwdntc, &
                                          aclwupb,aclwupbc,aclwupt,aclwuptc
- real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,ac_noahres
+ real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,acnoahres
  real(kind=RKIND),dimension(:),pointer:: nsteps_accum,ndays_accum,tday_accum, &
                                          tyear_accum,tyear_mean
  real(kind=RKIND),dimension(:),pointer:: sst,sstsk,tmn,xice,xicem

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -125,11 +125,13 @@ use mpas_stream_manager
                                 i_acswupb,i_acswupbc,i_acswupt,i_acswuptc, &
                                 i_aclwdnb,i_aclwdnbc,i_aclwdnt,i_aclwdntc, &
                                 i_aclwupb,i_aclwupbc,i_aclwupt,i_aclwuptc
+ integer,dimension(:),pointer:: i_achfx,i_acqfx,i_aclh,i_acgrdflx,i_acnoahres
 
  real(kind=RKIND),dimension(:),pointer:: acswdnb,acswdnbc,acswdnt,acswdntc, &
                                          acswupb,acswupbc,acswupt,acswuptc, &
                                          aclwdnb,aclwdnbc,aclwdnt,aclwdntc, &
                                          aclwupb,aclwupbc,aclwupt,aclwuptc
+ real(kind=RKIND),dimension(:),pointer  :: achfx,acqfx,aclh,acgrdflx,ac_noahres
  real(kind=RKIND),dimension(:),pointer:: nsteps_accum,ndays_accum,tday_accum, &
                                          tyear_accum,tyear_mean
  real(kind=RKIND),dimension(:),pointer:: sst,sstsk,tmn,xice,xicem
@@ -191,6 +193,12 @@ use mpas_stream_manager
  call mpas_pool_get_array(diag_physics,'i_aclwupt'   ,i_aclwupt   )
  call mpas_pool_get_array(diag_physics,'i_aclwuptc'  ,i_aclwuptc  )
 
+ call mpas_pool_get_array(diag_physics,'i_achfx'     ,i_achfx     )
+ call mpas_pool_get_array(diag_physics,'i_acqfx'     ,i_acqfx     )
+ call mpas_pool_get_array(diag_physics,'i_aclh'      ,i_aclh      )
+ call mpas_pool_get_array(diag_physics,'i_acgrdflx'  ,i_acgrdflx  )
+ call mpas_pool_get_array(diag_physics,'i_acnoahres' ,i_acnoahres )
+
  call mpas_pool_get_array(diag_physics,'acswdnb'     ,acswdnb     )
  call mpas_pool_get_array(diag_physics,'acswdnbc'    ,acswdnbc    )
  call mpas_pool_get_array(diag_physics,'acswdnt'     ,acswdnt     )
@@ -207,6 +215,12 @@ use mpas_stream_manager
  call mpas_pool_get_array(diag_physics,'aclwupbc'    ,aclwupbc    )
  call mpas_pool_get_array(diag_physics,'aclwupt'     ,aclwupt     )
  call mpas_pool_get_array(diag_physics,'aclwuptc'    ,aclwuptc    )
+
+ call mpas_pool_get_array(diag_physics,'achfx'       ,achfx       )
+ call mpas_pool_get_array(diag_physics,'acqfx'       ,acqfx       )
+ call mpas_pool_get_array(diag_physics,'aclh'        ,aclh        )
+ call mpas_pool_get_array(diag_physics,'acgrdflx'    ,acgrdflx    )
+ call mpas_pool_get_array(diag_physics,'acnoahres'   ,acnoahres   )
 
  call mpas_pool_get_array(diag_physics,'nsteps_accum',nsteps_accum)
  call mpas_pool_get_array(diag_physics,'ndays_accum' ,ndays_accum )
@@ -304,6 +318,25 @@ use mpas_stream_manager
        aclwupbc(iCell) = 0._RKIND
        aclwupt(iCell)  = 0._RKIND
        aclwuptc(iCell) = 0._RKIND
+    enddo
+ endif
+
+! Initialisation of accumlated surface fluxes and corresponding counters (i_ac*). Counters i_ac* track
+! the number of times the absolute value of the accumulated surface fluxes exceed their prescribed 
+! threshold values.
+ if(.not. config_do_restart .and. config_lsm_scheme.ne.'off') then
+    do iCell = 1, nCellsSolve
+       i_achfx    (iCell) = 0
+       i_acqfx    (iCell) = 0
+       i_aclh     (iCell) = 0
+       i_acgrdflx (iCell) = 0
+       i_acnoahres(iCell) = 0
+
+       achfx      (iCell) = 0._RKIND
+       acqfx      (iCell) = 0._RKIND
+       aclh       (iCell) = 0._RKIND
+       acgrdflx   (iCell) = 0._RKIND
+       acnoahres  (iCell) = 0._RKIND
     enddo
  endif
 

--- a/src/core_atmosphere/physics/mpas_atmphys_init.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_init.F
@@ -321,7 +321,7 @@ use mpas_stream_manager
     enddo
  endif
 
-! Initialisation of accumlated surface fluxes and corresponding counters (i_ac*). Counters i_ac* track
+! Initialisation of accumulated surface fluxes and corresponding counters (i_ac*). Counters i_ac* track
 ! the number of times the absolute value of the accumulated surface fluxes exceed their prescribed 
 ! threshold values.
  if(.not. config_do_restart .and. config_lsm_scheme.ne.'off') then

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -61,6 +61,11 @@
  character(len=*), parameter:: acradtAlarmID   = 'acradt'
  type(MPAS_TimeInterval_Type):: acradtTimeStep
 
+!defines alarm to check if the accumulated surface flux diagnostics are greater than
+!their maximum allowed value:
+ character(len=*), parameter:: acsflxAlarmID   = 'acsflx'
+ type(MPAS_TimeInterval_Type):: acsflxTimeStep
+
 !defines alarm to compute some physics diagnostics, such as radar reflectivity:
  character(len=*), parameter:: diagAlarmID     = 'diag'
 
@@ -359,6 +364,16 @@
     call mpas_log_write('--- time to apply limit to accumulated radiation diags. L_ACRADT   =$l',logicArgs=(/l_acradt/))
  endif
 
+!check to see if it is time to apply limit to the surface flux diagnostics:
+ if(trim(config_lsm_scheme) /= "off") then
+    l_acsflx = .false.
+    if(mpas_is_alarm_ringing(clock,acsflxAlarmID,acsflxTimeStep,ierr=ierr)) then
+       call mpas_reset_clock_alarm(clock,acsflxAlarmID,acsflxTimeStep,ierr=ierr)
+       l_acsflx = .true.
+    endif
+    call mpas_log_write('--- time to apply limit to accumulated surface flux diags. L_ACSFLX   =$l',logicArgs=(/l_acsflx/))
+ endif
+
 !check to see if it is time to calculate additional physics diagnostics:
  l_diags = .false.
  if (mpas_is_alarm_ringing(clock,diagAlarmID,ierr=ierr)) then
@@ -611,6 +626,17 @@
           call physics_error_fatal('subroutine physics_init: error creating alarm radiation limit')
  endif
 
+!set alarm to check if the accumulated surface flux diagnostics is greater than its maximum
+!allowed value:
+ if(config_bucket_update /= "none") then
+    call mpas_set_timeInterval(acsflxTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
+    alarmStartTime = startTime + alarmTimeStep
+    call mpas_add_clock_alarm(clock,acsflxAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+       if(ierr /= 0) &
+          call physics_error_fatal('subroutine physics_init: error creating alarm surface-flux limit')
+ endif
+
 !set alarm to calculate physics diagnostics on IO outpt only:
  call MPAS_stream_mgr_get_property(stream_manager, 'output', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
                                    direction=MPAS_STREAM_OUTPUT, ierr=ierr)
@@ -703,6 +729,7 @@
  l_camlw  = .false.
  l_acrain = .false.
  l_acradt = .false.
+ l_acsflx = .false.
 
 !initialization for CAM radiation schemes only:
  if(trim(config_radt_lw_scheme) .eq. "cam_lw" .or. &

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -159,7 +159,8 @@
 
  character(len=StrKIND),pointer:: config_convection_scheme, &
                                   config_radt_lw_scheme,    &
-                                  config_radt_sw_scheme
+                                  config_radt_sw_scheme,    &
+                                  config_lsm_scheme
 
  character(len=StrKIND),pointer:: config_conv_interval,    &
                                   config_radtlw_interval,  &
@@ -188,8 +189,9 @@
 !call mpas_log_write('--- enter subroutine physics_timetracker: itimestep = $i', intArgs=(/itimestep/))
 
  call mpas_pool_get_config(domain%blocklist%configs,'config_convection_scheme',config_convection_scheme)
- call mpas_pool_get_config(domain%blocklist%configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme  )
- call mpas_pool_get_config(domain%blocklist%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme  )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_lsm_scheme'       ,config_lsm_scheme       )
 
  call mpas_pool_get_config(domain%blocklist%configs,'config_conv_interval'   ,config_conv_interval   )
  call mpas_pool_get_config(domain%blocklist%configs,'config_radtlw_interval' ,config_radtlw_interval )

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -161,7 +161,8 @@
 
  character(len=StrKIND),pointer:: config_convection_scheme, &
                                   config_radt_lw_scheme,    &
-                                  config_radt_sw_scheme
+                                  config_radt_sw_scheme,    &
+                                  config_lsm_scheme
 
  character(len=StrKIND),pointer:: config_conv_interval,    &
                                   config_radtlw_interval,  &
@@ -192,6 +193,7 @@
  call mpas_pool_get_config(domain%blocklist%configs,'config_convection_scheme',config_convection_scheme)
  call mpas_pool_get_config(domain%blocklist%configs,'config_radt_lw_scheme'   ,config_radt_lw_scheme   )
  call mpas_pool_get_config(domain%blocklist%configs,'config_radt_sw_scheme'   ,config_radt_sw_scheme   )
+ call mpas_pool_get_config(domain%blocklist%configs,'config_lsm_scheme'       ,config_lsm_scheme       )
 
  call mpas_pool_get_config(domain%blocklist%configs,'config_conv_interval'  ,config_conv_interval  )
  call mpas_pool_get_config(domain%blocklist%configs,'config_radtlw_interval',config_radtlw_interval)

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -632,7 +632,7 @@
 !set alarm to check if the accumulated surface flux diagnostics is greater than its maximum
 !allowed value:
  if(config_bucket_update /= "none") then
-    call mpas_set_timeInterval(acsflxTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(acsflxTimeStep,dt=dt,ierr=ierr)
     call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
     alarmStartTime = startTime + alarmTimeStep
     call mpas_add_clock_alarm(clock,acsflxAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -63,6 +63,11 @@
  character(len=*), parameter:: acradtAlarmID   = 'acradt'
  type(MPAS_TimeInterval_Type):: acradtTimeStep
 
+!defines alarm to check if the accumulated surface flux diagnostics are greater than
+!their maximum allowed value:
+ character(len=*), parameter:: acsflxAlarmID   = 'acsflx'
+ type(MPAS_TimeInterval_Type):: acsflxTimeStep
+
 !defines alarm to compute some physics diagnostics, such as radar reflectivity:
  character(len=*), parameter:: diagAlarmID     = 'diag'
 
@@ -361,6 +366,16 @@
     call mpas_log_write('--- time to apply limit to accumulated radiation diags. L_ACRADT   = $l',logicArgs=(/l_acradt/))
  endif
 
+!check to see if it is time to apply limit to the surface flux diagnostics:
+ if(trim(config_lsm_scheme) /= "off") then
+    l_acsflx = .false.
+    if(mpas_is_alarm_ringing(clock,acsflxAlarmID,acsflxTimeStep,ierr=ierr)) then
+       call mpas_reset_clock_alarm(clock,acsflxAlarmID,acsflxTimeStep,ierr=ierr)
+       l_acsflx = .true.
+    endif
+    call mpas_log_write('--- time to apply limit to accumulated surface flux diags. L_ACSFLX   =$l',logicArgs=(/l_acsflx/))
+ endif
+
 !check to see if it is time to calculate additional physics diagnostics:
  l_diags = .false.
  if (mpas_is_alarm_ringing(clock,diagAlarmID,ierr=ierr)) then
@@ -612,6 +627,17 @@
           call physics_error_fatal('subroutine physics_init: error creating alarm radiation limit')
  endif
 
+!set alarm to check if the accumulated surface flux diagnostics is greater than its maximum
+!allowed value:
+ if(config_bucket_update /= "none") then
+    call mpas_set_timeInterval(acsflxTimeStep,dt=config_dt,ierr=ierr)
+    call mpas_set_timeInterval(alarmTimeStep,timeString=config_bucket_update,ierr=ierr)
+    alarmStartTime = startTime + alarmTimeStep
+    call mpas_add_clock_alarm(clock,acsflxAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)
+       if(ierr /= 0) &
+          call physics_error_fatal('subroutine physics_init: error creating alarm surface-flux limit')
+ endif
+
 !set alarm to calculate physics diagnostics on IO outpt only:
  call MPAS_stream_mgr_get_property(stream_manager, 'output', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
                                    direction=MPAS_STREAM_OUTPUT, ierr=ierr)
@@ -708,6 +734,7 @@
  l_camlw  = .false.
  l_acrain = .false.
  l_acradt = .false.
+ l_acsflx = .false.
 
 !initialization for CAM radiation schemes only:
  if(trim(config_radt_lw_scheme) .eq. "cam_lw" .or. &

--- a/src/core_atmosphere/physics/mpas_atmphys_update.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update.F
@@ -16,7 +16,8 @@
  implicit none
  private
  public:: physics_update, &
-          update_radiation_diagnostics
+          update_radiation_diagnostics, &
+          update_sfcflux_diagnostics
 
 
 !Update diagnostics.
@@ -27,6 +28,7 @@
 ! -----------------------------------
 ! physics_update              : not used.
 ! update_radiation_diagnostics: update accumulated radiation diagnostics.
+! update_sfcflux_diagnostics: update accumulated surface flux diagnostics.
 !
 ! add-ons and modifications to sourcecode:
 ! ----------------------------------------
@@ -252,6 +254,99 @@
  endif
 
  end subroutine update_radiation_diagnostics
+
+!=================================================================================================================
+ subroutine update_lsm_diagnostics(configs,mesh,diag_physics,its,ite)
+!=================================================================================================================
+
+!input arguments:
+ type(mpas_pool_type),intent(in):: configs
+ type(mpas_pool_type),intent(in):: mesh
+ integer,intent(in):: its,ite
+
+!inout arguments:
+ type(mpas_pool_type),intent(inout):: diag_physics
+
+!local pointers:
+ integer,pointer:: nCellsSolve
+ integer,dimension(:),pointer  :: i_achfx, i_acqfx, i_aclh, i_grdflx, i_acnoahres
+
+ real(kind=RKIND),pointer:: bucket_lsm
+ real(kind=RKIND),dimension(:),pointer:: hfx  , qfx  , lh  , grdflx  , noahres
+ real(kind=RKIND),dimension(:),pointer:: achfx, acqfx, aclh, acgrdflx, acnoahres
+
+!local variables and arrays:
+ integer:: iCell
+
+!-----------------------------------------------------------------------------------------------------------------
+
+ call mpas_pool_get_config(configs,'config_bucket_lsm',bucket_lsm)
+
+ call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
+
+ call mpas_pool_get_array(diag_physics,'i_achfx'     , i_achfx     )
+ call mpas_pool_get_array(diag_physics,'i_acqfx'     , i_acqfx     )
+ call mpas_pool_get_array(diag_physics,'i_aclh'      , i_aclh      )
+ call mpas_pool_get_array(diag_physics,'i_acgrdflx'  , i_acgrdflx  )
+ call mpas_pool_get_array(diag_physics,'i_acnoahres' , i_acnoahres )
+
+ call mpas_pool_get_array(diag_physics,'achfx'       , achfx       )
+ call mpas_pool_get_array(diag_physics,'acqfx'       , acqfx       )
+ call mpas_pool_get_array(diag_physics,'aclh'        , aclh        )
+ call mpas_pool_get_array(diag_physics,'acgrdflx'    , acgrdflx    )
+ call mpas_pool_get_array(diag_physics,'acnoahres'   , acnoahres   )
+
+ call mpas_pool_get_array(diag_physics,'hfx'         , hfx         )
+ call mpas_pool_get_array(diag_physics,'qfx'         , qfx         )
+ call mpas_pool_get_array(diag_physics,'lh'          , lh          )
+ call mpas_pool_get_array(diag_physics,'grdflx'      , grdflx      )
+ call mpas_pool_get_array(diag_physics,'noahres'     , noahres     )
+
+ do iCell = its, ite
+    achfx    (iCell) = achfx    (iCell) + hfx    (ICell) * dt_dyn
+    acqfx    (iCell) = acqfx    (iCell) + qfx    (ICell) * dt_dyn
+    aclh     (iCell) = aclh     (iCell) + lh     (ICell) * dt_dyn
+    acgrdflx (iCell) = acgrdflx (iCell) + grdflx (ICell) * dt_dyn
+    acnoahres(iCell) = acnoahres(iCell) + noahres(ICell) * dt_dyn
+ end do
+
+ if (l_acsflx .and. bucket_sflx > 0._RKIND) then
+    do iCell = its, ite
+
+       !    For the time being we apply the bucket logic to the surface fluxes. However,
+       ! these fluxes can be either positive or negative, so we must apply a two-sided
+       ! bucket to avoid positive and negative overflow.
+       if(abs(achfx(iCell)) > bucket_sflx) then
+          i_achfx(iCell) = i_achfx(iCell) + 1
+          achfx  (iCell) = sign(achfx(iCell),1.) * (abs(achfx(iCell) - bucket_sflx))
+       end if
+
+       if(abs(acqfx(iCell)) > bucket_sflx) then
+          i_acqfx(iCell) = i_acqfx(iCell) + 1
+          acqfx  (iCell) = sign(acqfx(iCell),1.) * (abs(acqfx(iCell) - bucket_sflx))
+       end if
+
+       if(abs(aclh (iCell)) > bucket_sflx) then
+          i_aclh(iCell) = i_aclh(iCell) + 1
+          aclh  (iCell) = sign(aclh(iCell),1.) * (abs(aclh(iCell) - bucket_sflx))
+       end if
+
+       if(abs(acgrdflx(iCell)) > bucket_sflx) then
+          i_acgrdflx(iCell) = i_acgrdflx(iCell) + 1
+          acgrdflx  (iCell) = &
+             sign(acgrdflx(iCell),1.) * (abs(acgrdflx(iCell) - bucket_sflx))
+       end if
+
+       if(abs(acnoahres(iCell)) > bucket_sflx) then
+          i_acnoahres(iCell) = i_acnoahres(iCell) + 1
+          acnoahres  (iCell) = &
+             sign(acnoahres(iCell),1.) * (abs(acnoahres(iCell) - bucket_sflx))
+       end if
+    end do
+
+ end if
+
+ end subroutine update_lsm_diagnostics
 
 !=================================================================================================================
  end module mpas_atmphys_update

--- a/src/core_atmosphere/physics/mpas_atmphys_update.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update.F
@@ -271,7 +271,7 @@
  integer,pointer:: nCellsSolve
  integer,dimension(:),pointer  :: i_achfx, i_acqfx, i_aclh, i_acgrdflx, i_acnoahres
 
- real(kind=RKIND),pointer:: bucket_lsm
+ real(kind=RKIND),pointer:: bucket_sflx
  real(kind=RKIND),dimension(:),pointer:: hfx  , qfx  , lh  , grdflx  , noahres
  real(kind=RKIND),dimension(:),pointer:: achfx, acqfx, aclh, acgrdflx, acnoahres
 
@@ -280,7 +280,7 @@
 
 !-----------------------------------------------------------------------------------------------------------------
 
- call mpas_pool_get_config(configs,'config_bucket_lsm',bucket_lsm)
+ call mpas_pool_get_config(configs,'config_bucket_sflx',bucket_sflx)
 
  call mpas_pool_get_dimension(mesh,'nCellsSolve',nCellsSolve)
 

--- a/src/core_atmosphere/physics/mpas_atmphys_update.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update.F
@@ -256,7 +256,7 @@
  end subroutine update_radiation_diagnostics
 
 !=================================================================================================================
- subroutine update_lsm_diagnostics(configs,mesh,diag_physics,its,ite)
+ subroutine update_sfcflux_diagnostics(configs,mesh,diag_physics,its,ite)
 !=================================================================================================================
 
 !input arguments:
@@ -269,7 +269,7 @@
 
 !local pointers:
  integer,pointer:: nCellsSolve
- integer,dimension(:),pointer  :: i_achfx, i_acqfx, i_aclh, i_grdflx, i_acnoahres
+ integer,dimension(:),pointer  :: i_achfx, i_acqfx, i_aclh, i_acgrdflx, i_acnoahres
 
  real(kind=RKIND),pointer:: bucket_lsm
  real(kind=RKIND),dimension(:),pointer:: hfx  , qfx  , lh  , grdflx  , noahres
@@ -346,7 +346,7 @@
 
  end if
 
- end subroutine update_lsm_diagnostics
+ end subroutine update_sfcflux_diagnostics
 
 !=================================================================================================================
  end module mpas_atmphys_update

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -146,6 +146,7 @@
  logical:: l_diags                    !controls when to calculate physics diagnostics.
  logical:: l_acrain                   !when .true., limit to accumulated rain is applied.
  logical:: l_acradt                   !when .true., limit to lw and sw radiation is applied.
+ logical:: l_acsflx                   !when .true., limit to surface fluxes is applied.
  logical:: l_mp_tables                !when .true., read look-up tables for Thompson cloud microphysics scheme.
 
  integer,public:: ids,ide,jds,jde,kds,kde

--- a/src/core_atmosphere/physics/mpas_atmphys_vars.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_vars.F
@@ -148,6 +148,7 @@
  logical:: l_diags                    !controls when to calculate physics diagnostics.
  logical:: l_acrain                   !when .true., limit to accumulated rain is applied.
  logical:: l_acradt                   !when .true., limit to lw and sw radiation is applied.
+ logical:: l_acsflx                   !when .true., limit to surface fluxes is applied.
  logical:: l_mp_tables                !when .true., read look-up tables for Thompson cloud microphysics scheme.
 
  integer,public:: ids,ide,jds,jde,kds,kde


### PR DESCRIPTION
### Pull Request Description

This code adds new variables that accumulate surface fluxes over time for generic variables used by all land surface models.  This implementation closely follow the same logic used to integrate radiation fluxes. This PR only adds new diagnostic variables, and they do not interfere with the calculation of the actual fluxes.

This is intended to be the first of a sequence of PRs that will add this functionality. In a future PR, I will propose removing the cumulative "bucket" altogether, and repurpose the existing `config_bucket_update` variable to specify when to reset cumulative variables at regular intervals (regardless of whether or not the cumulative variables exceeded a certain threshold).

I am currently having problems with `convert_mpas` that seems to be independent on my code edits. ~Once I confirm the cumulative fluxes are working as intended I will update the status to "ready for review".~ **Update:** tests ran successfully, so I am setting this PR as ready for review.

### Type of Change

- [ ] Bug fix
- [ ] Hot fix
- [x] New feature
- [ ] Improvement to existing functionality
- [ ] Code refactoring
- [ ] Code optimization
- [ ] Other: ______

### Testing and Quality

- [ ] Code was written following MONAN’s DTN-01 (Coding Standard)
- [ ] Compilation and execution tests of the model were executed
- [ ] Test with the debug flag was executed
- [ ] Results are reproducible with the default configuration

### Scientific Impact

Currently, MONAN does not report averaged values for surface fluxes, which is frequently what observations report. The addition of these variables will facilitate model benchmarking.