### PR TITLE
Soil layer bug

### DIFF
--- a/src/core_atmosphere/physics/Registry_noahmp.xml
+++ b/src/core_atmosphere/physics/Registry_noahmp.xml
@@ -16,7 +16,7 @@
       <dim name="nSnowLevels" definition="3"
                 description="The number of snow layers used by the NOAHMP land-surface scheme"/>
 
-      <dim name="nzSnowLevels" definition="7"
+      <dim name="nzSnowLevels" definition="nSoilLevels+nSnowLevels"
                 description="The number of snow layer depths used by the NOAHMP land-surface scheme"/>
 
  </dims>

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_lsm_noahmp.F
@@ -842,12 +842,8 @@
        snicexy(ns,i) = mpas_noahmp%snicexy(i,n)
        snliqxy(ns,i) = mpas_noahmp%snliqxy(i,n)
     enddo
-    do ns = 1,nsnow
+    do ns = 1,nzsnow
        n = ns - nsnow
-       zsnsoxy(ns,i) = mpas_noahmp%zsnsoxy(i,n)
-    enddo
-    do ns = nsnow+1,nzsnow
-       n = ns - nsoil + 1
        zsnsoxy(ns,i) = mpas_noahmp%zsnsoxy(i,n)
     enddo
  enddo


### PR DESCRIPTION

### Pull Request Description

This is a rather cryptic bug, that only occurs when the number of soil layers is not the default (4 layers) for Noah-MP, which results in the model not conserving water. 

**1. Soil layer indexing bug.** Noah-MP uses positive indices for soil layers, and negative indices for snowpack layers. In sub-routine `lsm_noahmp_toMPAS`, the code copies the depths from Noah-MP to a local structure (`zsnsoxy`) that assumes indices going from 1 to the number of combined snowpack and soil layers. However, the original code had one error in the conversion logic, which coincidentally worked for the specific case in which the number of soil layers is exactly the number of snowpack ayers plus 1. The proposed change is used elsewhere in the code and ensures the conversion always works.

**2. Hardcoded number of soil plus snow levels.** File `Registry_noahmp.xml` originally defines dimension `nzSnowLevels` (total number of soil plus snowpack layers) as 7. This works when using the default number of soil layers, but causes segmentation violations otherwise. 

This is a quick hot fix, which will be followed by a subsequent pull request that allows for a more flexible definition of soil levels for Noah and Noah-MP.

### Type of Change

- [ ] Bug fix
- [x] Hot fix
- [ ] New feature
- [ ] Improvement to existing functionality
- [ ] Code refactoring
- [ ] Code optimization
- [ ] Other: ______

### Testing and Quality

- [ ] Code was written following MONAN’s DTN-01 (Coding Standard)
- [ ] Compilation and execution tests of the model were executed
- [ ] Test with the debug flag was executed
- [ ] Results are reproducible with the default configuration

### Scientific Impact

Bug fix. This will not impact simulations using the default number of layers, but it will allow generalising the solution for soils with more layers.
