### PR TITLE
Update default physics options for mesoscale_reference_monan and convection_permitting_monan with noahmp and ugwp parameters

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -157,13 +157,11 @@ else if (trim(config_physics_suite) == 'mesoscale_reference_monan') then
     if (trim(config_microp_scheme)     == 'suite') config_microp_scheme     = 'mp_wsm6'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'cu_gf_monan'
     if (trim(config_pbl_scheme)        == 'suite') config_pbl_scheme        = 'bl_mynn'
-!   if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
     if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ugwp_gwdo'
     if (trim(config_radt_lw_scheme)    == 'suite') config_radt_lw_scheme    = 'rrtmg_lw'
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction_monan'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_mynn'
-!   if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
     if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noahmp'
     
  else if (trim(config_physics_suite) == 'convection_permitting_monan') then
@@ -171,13 +169,11 @@ else if (trim(config_physics_suite) == 'mesoscale_reference_monan') then
     if (trim(config_microp_scheme)     == 'suite') config_microp_scheme     = 'mp_thompson'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'cu_gf_monan'
     if (trim(config_pbl_scheme)        == 'suite') config_pbl_scheme        = 'bl_mynn'
-!   if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
     if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ugwp_gwdo'
     if (trim(config_radt_lw_scheme)    == 'suite') config_radt_lw_scheme    = 'rrtmg_lw'
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction_monan'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_mynn'
-!   if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
     if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noahmp'
 
  else if (trim(config_physics_suite) == 'none') then

--- a/src/core_atmosphere/physics/mpas_atmphys_control.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_control.F
@@ -157,24 +157,28 @@ else if (trim(config_physics_suite) == 'mesoscale_reference_monan') then
     if (trim(config_microp_scheme)     == 'suite') config_microp_scheme     = 'mp_wsm6'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'cu_gf_monan'
     if (trim(config_pbl_scheme)        == 'suite') config_pbl_scheme        = 'bl_mynn'
-    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
+!   if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
+    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ugwp_gwdo'
     if (trim(config_radt_lw_scheme)    == 'suite') config_radt_lw_scheme    = 'rrtmg_lw'
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction_monan'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_mynn'
-    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
-
+!   if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
+    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noahmp'
+    
  else if (trim(config_physics_suite) == 'convection_permitting_monan') then
 
     if (trim(config_microp_scheme)     == 'suite') config_microp_scheme     = 'mp_thompson'
     if (trim(config_convection_scheme) == 'suite') config_convection_scheme = 'cu_gf_monan'
     if (trim(config_pbl_scheme)        == 'suite') config_pbl_scheme        = 'bl_mynn'
-    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
+!   if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ysu_gwdo'
+    if (trim(config_gwdo_scheme)       == 'suite') config_gwdo_scheme       = 'bl_ugwp_gwdo'
     if (trim(config_radt_lw_scheme)    == 'suite') config_radt_lw_scheme    = 'rrtmg_lw'
     if (trim(config_radt_sw_scheme)    == 'suite') config_radt_sw_scheme    = 'rrtmg_sw'
     if (trim(config_radt_cld_scheme)   == 'suite') config_radt_cld_scheme   = 'cld_fraction_monan'
     if (trim(config_sfclayer_scheme)   == 'suite') config_sfclayer_scheme   = 'sf_mynn'
-    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
+!   if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noah'
+    if (trim(config_lsm_scheme)        == 'suite') config_lsm_scheme        = 'sf_noahmp'
 
  else if (trim(config_physics_suite) == 'none') then
 


### PR DESCRIPTION
…its setting noahmp e ugwp_gwdo default parameters

### Pull Request Description

This PR updates the default physics configuration for the following MONAN suites:

- mesoscale_reference_monan
- convection_permitting_monan

The changes include:

- Setting `sf_noahmp` as the default land surface model.
- Setting `bl_ugwp_gwdo` as the default gravity wave drag option.

No other physics options were modified.

(...)

### Type of Change

- [ ] Bug fix
- [ ] Hot fix
- [ ] New feature
- [ x ] Improvement to existing functionality
- [ ] Code refactoring
- [ ] Code optimization
- [ ] Other: ______

### Testing and Quality

- [ x ] Code was written following MONAN’s DTN-01 (Coding Standard)
- [ x ] Compilation and execution tests of the model were executed
- [ ] Test with the debug flag was executed
- [ ] Results are reproducible with the default configuration

### Scientific Impact

_Space for further details of the changes made and the improvements introduced. Cite the articles and references used._

(...)
