### PR TITLE
Adding vertically integrated microphysical variables

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -601,11 +601,11 @@
 			<var name="q2"/>
 			<var name="t2m"/>
 			<var name="precipw"/>
-                        <var name="precipci"/>
-                        <var name="precipcloud"/>
-                        <var name="precipice"/>
-                        <var name="precipgraupel"/>
-                        <var name="precipsnow"/>
+                        <var name="precipc"/>
+                        <var name="precipr"/>
+                        <var name="precipi"/>
+                        <var name="precipg"/>
+                        <var name="precips"/>
                         <var name="ctt"/>
 			<var name="dzs"/>
 			<var name="sh2o"/>
@@ -1012,11 +1012,11 @@
 			<var name="i_rainnc"/>
 			<var name="rainnc"/>
 			<var name="precipw"/>
-                        <var name="precipci"/>
-                        <var name="precipcloud"/>
-                        <var name="precipice"/>
-                        <var name="precipgraupel"/>
-                        <var name="precipsnow"/>
+                        <var name="precipc"/>
+                        <var name="precipr"/>
+                        <var name="precipi"/>
+                        <var name="precipg"/>
+                        <var name="precips"/>
                         <var name="ctt"/>
 			<var name="cuprec"/>
 			<var name="i_rainc"/>
@@ -1085,11 +1085,11 @@
 			<var name="refl10cm_1km"/>
 			<var name="refl10cm_1km_max"/>
 			<var name="precipw"/>
-			<var name="precipci"/>
-			<var name="precipcloud"/>
-			<var name="precipice"/>
-			<var name="precipgraupel"/>
-			<var name="precipsnow"/>
+                        <var name="precipc"/>
+                        <var name="precipr"/>
+                        <var name="precipi"/>
+                        <var name="precipg"/>
+                        <var name="precips"/>
             <var name="ctt"/>
             <var name="ctt"/>
 			<var name="u10"/>
@@ -1276,6 +1276,11 @@
 			<var name="q2"/>
 			<var name="t2m"/>
 			<var name="precipw"/>
+                        <var name="precipc"/>
+                        <var name="precipr"/>
+                        <var name="precipi"/>
+                        <var name="precipg"/>
+                        <var name="precips"/>
 			<var name="dzs"/>
 			<var name="zs"/>
 			<var name="ter"/>
@@ -2646,21 +2651,21 @@
 
                 <var name="precipw" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="precipitable water"/>
+                     
+               <var name="precipc" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="vertically-integrated cloud water content"/>
 
-               <var name="precipci" type="real" dimensions="nCells Time" units="kg m^{-2}"
-                     description="precipitable cloud and ice"/>
+               <var name="precipr" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="vertically-integrated rain content"/>
 
-               <var name="precipcloud" type="real" dimensions="nCells Time" units="kg m^{-2}"
-                     description="precipitable cloud water"/>
+               <var name="precipi" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="vertically-integrated cloud ice content"/>
 
-               <var name="precipice" type="real" dimensions="nCells Time" units="kg m^{-2}"
-                     description="precipitable ice"/>
+               <var name="precipg" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="vertically-integrated graupel content"/>
 
-               <var name="precipgraupel" type="real" dimensions="nCells Time" units="kg m^{-2}"
-                     description="precipitable graupel"/>
-
-               <var name="precipsnow" type="real" dimensions="nCells Time" units="kg m^{-2}"
-                     description="precipitable snow"/>
+               <var name="precips" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="vertically-integrated snow content"/>
 
                 <var name="ctt" type="real" dimensions="nCells Time" units="C"
                      description="cloud top temperature"/>

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -602,6 +602,10 @@
 			<var name="t2m"/>
 			<var name="precipw"/>
                         <var name="precipci"/>
+                        <var name="precipcloud"/>
+                        <var name="precipice"/>
+                        <var name="precipgraupel"/>
+                        <var name="precipsnow"/>
                         <var name="ctt"/>
 			<var name="dzs"/>
 			<var name="sh2o"/>
@@ -1009,6 +1013,10 @@
 			<var name="rainnc"/>
 			<var name="precipw"/>
                         <var name="precipci"/>
+                        <var name="precipcloud"/>
+                        <var name="precipice"/>
+                        <var name="precipgraupel"/>
+                        <var name="precipsnow"/>
                         <var name="ctt"/>
 			<var name="cuprec"/>
 			<var name="i_rainc"/>
@@ -1078,6 +1086,11 @@
 			<var name="refl10cm_1km_max"/>
 			<var name="precipw"/>
 			<var name="precipci"/>
+			<var name="precipcloud"/>
+			<var name="precipice"/>
+			<var name="precipgraupel"/>
+			<var name="precipsnow"/>
+            <var name="ctt"/>
             <var name="ctt"/>
 			<var name="u10"/>
 			<var name="v10"/>
@@ -2637,7 +2650,19 @@
                <var name="precipci" type="real" dimensions="nCells Time" units="kg m^{-2}"
                      description="precipitable cloud and ice"/>
 
-                <var name="ctt" type="real" dimensions="nCells Time" units="K"
+               <var name="precipcloud" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="precipitable cloud water"/>
+
+               <var name="precipice" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="precipitable ice"/>
+
+               <var name="precipgraupel" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="precipitable graupel"/>
+
+               <var name="precipsnow" type="real" dimensions="nCells Time" units="kg m^{-2}"
+                     description="precipitable snow"/>
+
+                <var name="ctt" type="real" dimensions="nCells Time" units="C"
                      description="cloud top temperature"/>
 			
                 <!-- ================================================================================================== -->

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -579,6 +579,7 @@
  integer,dimension(:),pointer:: i_rainnc
 
  real(kind=RKIND),pointer:: config_bucket_rainnc
+!  real(kind=RKIND),dimension(:),pointer:: precipw, precipci,precipcloud,precipice,precipgraupel,precipsnow
  real(kind=RKIND),dimension(:),pointer:: precipw
  real(kind=RKIND),dimension(:),pointer:: graupelnc,rainnc,snownc
  real(kind=RKIND),dimension(:),pointer:: graupelncv,rainncv,snowncv,sr
@@ -594,6 +595,12 @@
 
  call mpas_pool_get_array(diag_physics,'i_rainnc'  ,i_rainnc  )
  call mpas_pool_get_array(diag_physics,'precipw'   ,precipw   )
+ call mpas_pool_get_array(diag_physics,'precipci'   ,precipci   )
+ call mpas_pool_get_array(diag_physics,'precipcloud'   ,precipcloud   )
+ call mpas_pool_get_array(diag_physics,'precipice'   ,precipice   )
+ call mpas_pool_get_array(diag_physics,'precipgraupel'   ,precipgraupel   )
+ call mpas_pool_get_array(diag_physics,'precipsnow'   ,precipsnow   )
+
  call mpas_pool_get_array(diag_physics,'graupelnc' ,graupelnc )
  call mpas_pool_get_array(diag_physics,'graupelncv',graupelncv)
  call mpas_pool_get_array(diag_physics,'rainnc'    ,rainnc    )
@@ -649,6 +656,15 @@
           !accumulated precipitation:
           snownc(i)    = snownc(i) + snowncv(i)
           graupelnc(i) = graupelnc(i) + graupelncv(i)
+
+         !  do k = kts,kte
+         !      rho_a = rho_p(i,k,j) / (1._RKIND + qv_p(i,k,j))
+         !      precipci(i) = precipci(i) + (qc_p(i,k,j) + qi_p(i,k,j)) * rho_a * dz_p(i,k,j)
+         !      precipcloud(i) = precipcloud(i) + qc_p(i,k,j) * rho_a * dz_p(i,k,j)
+         !      precipice(i) = precipice(i) + qi_p(i,k,j) * rho_a * dz_p(i,k,j)
+         !      precipgraupel(i) = precipgraupel(i) + qg_p(i,k,j) * rho_a * dz_p(i,k,j)
+         !      precipsnow(i) = precipsnow(i) + qs_p(i,k,j) * rho_a * dz_p(i,k,j)
+         !  enddo
        enddo
        enddo
 

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_microphysics.F
@@ -579,8 +579,7 @@
  integer,dimension(:),pointer:: i_rainnc
 
  real(kind=RKIND),pointer:: config_bucket_rainnc
-!  real(kind=RKIND),dimension(:),pointer:: precipw, precipci,precipcloud,precipice,precipgraupel,precipsnow
- real(kind=RKIND),dimension(:),pointer:: precipw
+ real(kind=RKIND),dimension(:),pointer:: precipw,precipc,precipr,precipi,precipg,precips
  real(kind=RKIND),dimension(:),pointer:: graupelnc,rainnc,snownc
  real(kind=RKIND),dimension(:),pointer:: graupelncv,rainncv,snowncv,sr
 
@@ -595,11 +594,11 @@
 
  call mpas_pool_get_array(diag_physics,'i_rainnc'  ,i_rainnc  )
  call mpas_pool_get_array(diag_physics,'precipw'   ,precipw   )
- call mpas_pool_get_array(diag_physics,'precipci'   ,precipci   )
- call mpas_pool_get_array(diag_physics,'precipcloud'   ,precipcloud   )
- call mpas_pool_get_array(diag_physics,'precipice'   ,precipice   )
- call mpas_pool_get_array(diag_physics,'precipgraupel'   ,precipgraupel   )
- call mpas_pool_get_array(diag_physics,'precipsnow'   ,precipsnow   )
+ call mpas_pool_get_array(diag_physics,'precipc'   ,precipc   )
+ call mpas_pool_get_array(diag_physics,'precipr'   ,precipr   )
+ call mpas_pool_get_array(diag_physics,'precipi'   ,precipi   )
+ call mpas_pool_get_array(diag_physics,'precipg'   ,precipg   )
+ call mpas_pool_get_array(diag_physics,'precips'   ,precips   )
 
  call mpas_pool_get_array(diag_physics,'graupelnc' ,graupelnc )
  call mpas_pool_get_array(diag_physics,'graupelncv',graupelncv)
@@ -611,6 +610,11 @@
 
  do i = its,ite
     precipw(i) = 0._RKIND
+    precipc(i) = 0._RKIND
+    precipr(i) = 0._RKIND
+    precipi(i) = 0._RKIND
+    precipg(i) = 0._RKIND
+    precips(i) = 0._RKIND
  enddo
 
 !variables common to all cloud microphysics schemes:
@@ -657,14 +661,14 @@
           snownc(i)    = snownc(i) + snowncv(i)
           graupelnc(i) = graupelnc(i) + graupelncv(i)
 
-         !  do k = kts,kte
-         !      rho_a = rho_p(i,k,j) / (1._RKIND + qv_p(i,k,j))
-         !      precipci(i) = precipci(i) + (qc_p(i,k,j) + qi_p(i,k,j)) * rho_a * dz_p(i,k,j)
-         !      precipcloud(i) = precipcloud(i) + qc_p(i,k,j) * rho_a * dz_p(i,k,j)
-         !      precipice(i) = precipice(i) + qi_p(i,k,j) * rho_a * dz_p(i,k,j)
-         !      precipgraupel(i) = precipgraupel(i) + qg_p(i,k,j) * rho_a * dz_p(i,k,j)
-         !      precipsnow(i) = precipsnow(i) + qs_p(i,k,j) * rho_a * dz_p(i,k,j)
-         !  enddo
+          do k = kts,kte
+              rho_a = rho_p(i,k,j) / (1._RKIND + qv_p(i,k,j))
+              precipc(i) = precipc(i) + qc_p(i,k,j) * rho_a * dz_p(i,k,j)
+              precipr(i) = precipr(i) + qr_p(i,k,j) * rho_a * dz_p(i,k,j)
+              precipi(i) = precipi(i) + qi_p(i,k,j) * rho_a * dz_p(i,k,j)
+              precipg(i) = precipg(i) + qg_p(i,k,j) * rho_a * dz_p(i,k,j)
+              precips(i) = precips(i) + qs_p(i,k,j) * rho_a * dz_p(i,k,j)
+          enddo
        enddo
        enddo
 


### PR DESCRIPTION
Pull Request Description

This code adds new variables that integrate vertically the microphysical variables over the column, besides precipitable water vapor that was already implemented. These variables are named precipcloud, precipice, precipgraupel and precipsnow. The implementation is simple and follows the previous implementation of precipci (cloud + ice) by Saulo freitas, that was missing in this version although the variable precipci was in the registry. This implementation was added once again again.


### Type of Change

- [ ] Bug fix
- [ ] Hot fix
- [x] New feature
- [ ] Improvement to existing functionality
- [ ] Code refactoring
- [ ] Code optimization
- [ ] Other: ______

### Testing and Quality

- [ ] Code was written following MONAN’s DTN-01 (Coding Standard)
- [ ] Compilation and execution tests of the model were executed
- [ ] Test with the debug flag was executed
- [ ] Results are reproducible with the default configuration

### Scientific Impact

These variables are important to compare results with satellite data, and to understand radiative and microphysical processes that are acting in a region.
(...)
