### PR TITLE
Fix to soil colour initialisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,10 +690,10 @@ intel-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O3 -convert big_endian -FR -traceback" \
-        "CFLAGS_OPT = -O3 -std=gnu90 -traceback" \
-        "CXXFLAGS_OPT = -O3 -traceback" \
-        "LDFLAGS_OPT = -O3 -traceback" \
+        "FFLAGS_OPT = -O3 -convert big_endian -FR" \
+        "CFLAGS_OPT = -O3 -std=gnu90" \
+        "CXXFLAGS_OPT = -O3" \
+        "LDFLAGS_OPT = -O3" \
         "FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -ftrapuv -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
         "CFLAGS_DEBUG = -g -traceback" \
         "CXXFLAGS_DEBUG = -g -traceback" \
@@ -715,10 +715,10 @@ intel2-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O2 -convert big_endian -FR -traceback" \
-        "CFLAGS_OPT = -O2 -std=gnu90 -traceback" \
-        "CXXFLAGS_OPT = -O2 -traceback" \
-        "LDFLAGS_OPT = -O2 -traceback" \
+        "FFLAGS_OPT = -O2 -convert big_endian -FR" \
+        "CFLAGS_OPT = -O2 -std=gnu90" \
+        "CXXFLAGS_OPT = -O2" \
+        "LDFLAGS_OPT = -O2" \
         "FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -ftrapuv -traceback -Qoption,fpp,-macro_expand=vc" \
         "CFLAGS_DEBUG = -g -traceback" \
         "CFLAGS_DEBUG = -g -traceback" \

--- a/Makefile
+++ b/Makefile
@@ -690,10 +690,10 @@ intel-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O3 -convert big_endian -FR" \
-        "CFLAGS_OPT = -O3 -std=gnu90" \
-        "CXXFLAGS_OPT = -O3" \
-        "LDFLAGS_OPT = -O3" \
+        "FFLAGS_OPT = -O3 -convert big_endian -FR -traceback -check bounds,pointers" \
+        "CFLAGS_OPT = -O3 -std=gnu90 -traceback" \
+        "CXXFLAGS_OPT = -O3 -traceback" \
+        "LDFLAGS_OPT = -O3 -traceback" \
 	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
         "CFLAGS_DEBUG = -g -traceback" \
         "CXXFLAGS_DEBUG = -g -traceback" \
@@ -715,10 +715,10 @@ intel2-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O2 -convert big_endian -FR" \
-        "CFLAGS_OPT = -O2 -std=gnu90" \
-        "CXXFLAGS_OPT = -O2" \
-        "LDFLAGS_OPT = -O2" \
+        "FFLAGS_OPT = -O2 -convert big_endian -FR -traceback -check bounds,pointers" \
+        "CFLAGS_OPT = -O2 -std=gnu90 -traceback" \
+        "CXXFLAGS_OPT = -O2 -traceback" \
+        "LDFLAGS_OPT = -O2 -traceback" \
 	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
 	"CFLAGS_DEBUG = -g -traceback" \
         "CFLAGS_DEBUG = -g -traceback" \

--- a/Makefile
+++ b/Makefile
@@ -690,14 +690,14 @@ intel-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O3 -convert big_endian -FR -traceback -check bounds,pointers" \
+        "FFLAGS_OPT = -O3 -convert big_endian -FR -traceback" \
         "CFLAGS_OPT = -O3 -std=gnu90 -traceback" \
         "CXXFLAGS_OPT = -O3 -traceback" \
         "LDFLAGS_OPT = -O3 -traceback" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
+        "FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -ftrapuv -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
         "CFLAGS_DEBUG = -g -traceback" \
         "CXXFLAGS_DEBUG = -g -traceback" \
-	"LDFLAGS_DEBUG = -g -traceback" \
+        "LDFLAGS_DEBUG = -g -traceback" \
         "FFLAGS_OMP = -qopenmp" \
         "CFLAGS_OMP = -qopenmp" \
         "CORE = $(CORE)" \
@@ -715,12 +715,12 @@ intel2-xd2000:
         "CC_SERIAL = cc" \
         "CXX_SERIAL = CC" \
         "FFLAGS_PROMOTION = -real-size 64" \
-        "FFLAGS_OPT = -O2 -convert big_endian -FR -traceback -check bounds,pointers" \
+        "FFLAGS_OPT = -O2 -convert big_endian -FR -traceback" \
         "CFLAGS_OPT = -O2 -std=gnu90 -traceback" \
         "CXXFLAGS_OPT = -O2 -traceback" \
         "LDFLAGS_OPT = -O2 -traceback" \
-	"FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -traceback -Qoption,fpp,-macro_expand=vc" \
-	"CFLAGS_DEBUG = -g -traceback" \
+        "FFLAGS_DEBUG = -g -convert big_endian -free -check bounds,pointers,arg_temp_created,format,shape,contiguous -fpe0 -ftrapuv -traceback -Qoption,fpp,-macro_expand=vc" \
+        "CFLAGS_DEBUG = -g -traceback" \
         "CFLAGS_DEBUG = -g -traceback" \
         "CXXFLAGS_DEBUG = -g -traceback" \
         "LDFLAGS_DEBUG = -g -traceback" \

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -599,7 +599,7 @@
  integer, pointer:: nCellsSolve,nSoilLevels
  integer:: iCell,iSoil
  integer:: num_seaice_changes
- integer,dimension(:),pointer:: landmask,isltyp,ivgtyp
+ integer,dimension(:),pointer:: landmask,isltyp,isctyp,ivgtyp
 
  real(kind=RKIND):: xice_threshold
  real(kind=RKIND):: mid_point_depth

--- a/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_initialize_real.F
@@ -633,6 +633,7 @@
  call mpas_pool_get_array(mesh, 'landmask', landmask)
  call mpas_pool_get_array(mesh, 'lu_index', ivgtyp)
  call mpas_pool_get_array(mesh, 'soilcat_top', isltyp)
+ call mpas_pool_get_array(mesh, 'soilcol_idx', isctyp)
  call mpas_pool_get_array(mesh, 'snoalb', snoalb)
 
  call mpas_pool_get_array(input, 'seaice', seaice)
@@ -679,6 +680,7 @@
        if(landmask(iCell) .eq. 0) tmn(iCell) = 271.4_RKIND
        ivgtyp(iCell) = isice_lu
        isltyp(iCell) = 16
+       isctyp(iCell) = 4
        snoalb(iCell) = 0.75
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 1._RKIND

--- a/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_update_surface.F
@@ -138,7 +138,7 @@
  integer:: icheck
  integer:: iCell,iSoil
  integer:: nb_to_land,nb_to_ocean,nb_removed
- integer,dimension(:),pointer:: isltyp,ivgtyp,landmask
+ integer,dimension(:),pointer:: isltyp,isctyp,ivgtyp,landmask
 
  real(kind=RKIND):: local_min,local_max
  real(kind=RKIND):: global_sst_min,global_sst_max
@@ -152,6 +152,7 @@
  call mpas_pool_get_array(sfc_input,'isice'     ,isice     )
  call mpas_pool_get_array(sfc_input,'iswater'   ,iswater   )
  call mpas_pool_get_array(sfc_input,'isltyp'    ,isltyp    )
+ call mpas_pool_get_array(sfc_input,'isctyp'    ,isctyp    )
  call mpas_pool_get_array(sfc_input,'ivgtyp'    ,ivgtyp    )
  call mpas_pool_get_array(sfc_input,'landmask'  ,landmask  )
  call mpas_pool_get_array(sfc_input,'vegfra'    ,vegfra    )
@@ -218,6 +219,7 @@
     !... sea-ice points are converted to land points:
        ivgtyp(iCell) = isice
        isltyp(iCell) = 16
+       isctyp(iCell) = 4
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 1._RKIND
        tmn(iCell)    = 271.4_RKIND
@@ -243,6 +245,7 @@
        !land points turn to water points:
        ivgtyp(iCell) = iswater
        isltyp(iCell) = 14
+       isctyp(iCell) = 4
        vegfra(iCell) = 0._RKIND
        xland(iCell)  = 2._RKIND
        tmn(iCell)    = sst(iCell)

--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -249,6 +249,8 @@ module mpas_geotile_manager
                 call mpas_pool_add_config(mgr % pool, 'isoilwater', 14)
             endif
 
+            !    Set this to 4 so it works with all tables. It will be overwritten with 
+            ! the table-specific default if the data bases are not found.
             if (.not. associated(islcolwater)) then
                call mpas_pool_add_config(mgr % pool, 'islcolwater', 4)
             end if

--- a/src/core_init_atmosphere/mpas_geotile_manager.F
+++ b/src/core_init_atmosphere/mpas_geotile_manager.F
@@ -98,7 +98,7 @@ module mpas_geotile_manager
     !>     * isice = 24
     !>     * isurban = 1
     !>     * isoilwater = 14
-    !>     * islcolwater = 9
+    !>     * islcolwater = 4
     !
     !-----------------------------------------------------------------------
     function mpas_geotile_mgr_init(mgr, path) result(ierr)
@@ -250,7 +250,7 @@ module mpas_geotile_manager
             endif
 
             if (.not. associated(islcolwater)) then
-               call mpas_pool_add_config(mgr % pool, 'islcolwater', 1)
+               call mpas_pool_add_config(mgr % pool, 'islcolwater', 4)
             end if
         endif
 

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -479,7 +479,7 @@
        ! Set default category and default water category for NOAH soil colour.
        ! These will be overwritten if soil colour data sets exist.
        isdefault_slcol = 4
-       iswater_slcol   = 1
+       iswater_slcol   = 4
 
     case('MODIFIED_RAD_CLM_NOAH')
        call mpas_log_write('Using 21-class MODIS 30-arc-second land cover dataset')
@@ -487,8 +487,8 @@
 
        ! Set default category and default water category for NOAH soil colour
        ! These will be overwritten if soil colour data sets exist.
-       isdefault_slcol =  4
-       iswater_slcol   = 21
+       isdefault_slcol =  14
+       iswater_slcol   =  21
     case default
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)
        call mpas_log_write('Invalid soil colour dataset '''//trim(config_soilcol_data) &
@@ -510,12 +510,17 @@
  where (lu_index == isice_lu) soilcat_top = 16
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! KLUDGE TO REPLACE DUMMY OCEAN SOIL COLOUR WITH DEFAULT VALUES
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ where ( soilcol_idx == iswater_slcol ) soilcol_idx = isdefault_slcol
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! CORRECT INCONSISTENT SOIL TYPE, SOIL COLOUR AND LAND USE DATA
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  do iCell = 1,nCells
-    if (lu_index(iCell) == iswater_lu      .or. &
-        soilcat_top(iCell) == iswater_soil .or. &
-        soilcol_idx(iCell) == iswater_slcol ) then
+    if (lu_index(iCell)    == iswater_lu      .or. &
+        soilcat_top(iCell) == iswater_soil ) then
         if (lu_index(iCell) /= iswater_lu) then
             call mpas_log_write('Turning lu_index into water at $i', intArgs=(/iCell/))
             lu_index(iCell) = iswater_lu
@@ -524,10 +529,10 @@
             call mpas_log_write('Turning soilcat_top into water at $i', intArgs=(/iCell/))
             soilcat_top(iCell) = iswater_soil
         end if
-        if (soilcol_idx(iCell) /= iswater_slcol) then
-            call mpas_log_write('Turning soilcol_idx into water at $i', intArgs=(/iCell/))
-            soilcol_idx(iCell) = iswater_slcol
-        end if
+
+        ! Impose the default soil colour for the grid cell
+        call mpas_log_write('Turning soilcol_idx into default at $i', intArgs=(/iCell/))
+        soilcol_idx(iCell) = isdefault_slcol
     end if
  end do
 
@@ -2058,6 +2063,9 @@
 
          call mpas_pool_get_dimension(mesh, 'nCells', nCells)
          call mpas_pool_get_array(mesh, 'soilcol_idx', soilcol_idx)
+
+         ! Overwrite default soil colour to match the data base-specific default.
+         call mpas_pool_add_config(mgr % pool, 'islcolwater', iswater_slcol)
 
          ! Define the entire domain with the default soil colour index
          soilcol_idx(1:nCells) = isdefault_slcol

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -474,7 +474,7 @@
 !
  slcol_input_select1: select case(trim(config_soilcol_data))
     case('DEFAULT_RAD_NOAH')
-       call mpas_log_write('Using 9-class default NOAH soil colour classes')
+       call mpas_log_write('Using 8-class default NOAH soil colour classes')
        geog_sub_path = 'soilcolour_30s/'
        ! Set default category and default water category for NOAH soil colour.
        ! These will be overwritten if soil colour data sets exist.
@@ -487,7 +487,7 @@
 
        ! Set default category and default water category for NOAH soil colour
        ! These will be overwritten if soil colour data sets exist.
-       isdefault_slcol = 14
+       isdefault_slcol =  4
        iswater_slcol   = 21
     case default
        call mpas_log_write('*****************************************************************', messageType=MPAS_LOG_ERR)


### PR DESCRIPTION
### Pull Request Description

It turned out that my previous pull request to initialise spatially heterogeneous soil colour was crashing the model under some configurations. This pull request is an attempt to fix it. 

In short, I made 3 modifications:

1. The ocean flag in soil colour data sets is now replaced by a default soil colour class with valid albedo values.
2. The soil colour map is no longer used for consistency check for land/ocean masks. This reverts the logic back to MPAS default. If land use or soil texture flags a pixel as ocean, then soil colour is forced to the default value (which should not be used).
3. Sea ice initialisation assigned default values for soil texture. I added code so MONAN assigns a default value for soil colour too. This _shouldn't_ be ever needed, but I preferred to err on the side of caution.

I made some initial tests on Jaci and it seems to be running for 12 UTC initialisations. It is still unclear to me why the first PR would work at 00 UTC but not at 12 UTC. I suspect some pixel with inconsistent ocean/land flags existed on a place where it is nighttime at 00 UTC and daytime at 12 UTC.

### Type of Change

- [ ] Bug fix
- [x] Hot fix
- [ ] New feature
- [ ] Improvement to existing functionality
- [ ] Code refactoring
- [ ] Code optimization
- [ ] Other: ______

### Testing and Quality

- [ ] Code was written following MONAN’s DTN-01 (Coding Standard)
- [ ] Compilation and execution tests of the model were executed
- [ ] Test with the debug flag was executed
- [ ] Results are reproducible with the default configuration

### Scientific Impact

Hopefully this PR will allow MONAN-2.0.0-rc to run at 00 UTC and 12 UTC.
